### PR TITLE
Adds simple window management commands to calmwm

### DIFF
--- a/app/cwm/calmwm.h
+++ b/app/cwm/calmwm.h
@@ -417,6 +417,7 @@ void			 client_transient(struct client_ctx *);
 void			 client_unhide(struct client_ctx *);
 void			 client_urgency(struct client_ctx *);
 void 			 client_vtile(struct client_ctx *);
+void 			 client_vleft(struct client_ctx *);
 void			 client_wm_hints(struct client_ctx *);
 
 void			 group_alltoggle(struct screen_ctx *);
@@ -476,6 +477,7 @@ void			 kbfunc_client_toggle_hmaximize(void *, struct cargs *);
 void			 kbfunc_client_toggle_vmaximize(void *, struct cargs *);
 void 			 kbfunc_client_htile(void *, struct cargs *);
 void 			 kbfunc_client_vtile(void *, struct cargs *);
+void 			 kbfunc_client_vleft(void *, struct cargs *);
 void			 kbfunc_client_cycle(void *, struct cargs *);
 void			 kbfunc_client_toggle_group(void *, struct cargs *);
 void			 kbfunc_client_movetogroup(void *, struct cargs *);

--- a/app/cwm/calmwm.h
+++ b/app/cwm/calmwm.h
@@ -418,6 +418,7 @@ void			 client_unhide(struct client_ctx *);
 void			 client_urgency(struct client_ctx *);
 void 			 client_vtile(struct client_ctx *);
 void 			 client_vleft(struct client_ctx *);
+void 			 client_vright(struct client_ctx *);
 void			 client_wm_hints(struct client_ctx *);
 
 void			 group_alltoggle(struct screen_ctx *);
@@ -478,6 +479,7 @@ void			 kbfunc_client_toggle_vmaximize(void *, struct cargs *);
 void 			 kbfunc_client_htile(void *, struct cargs *);
 void 			 kbfunc_client_vtile(void *, struct cargs *);
 void 			 kbfunc_client_vleft(void *, struct cargs *);
+void 			 kbfunc_client_vright(void *, struct cargs *);
 void			 kbfunc_client_cycle(void *, struct cargs *);
 void			 kbfunc_client_toggle_group(void *, struct cargs *);
 void			 kbfunc_client_movetogroup(void *, struct cargs *);

--- a/app/cwm/client.c
+++ b/app/cwm/client.c
@@ -1092,7 +1092,6 @@ client_vtile(struct client_ctx *cc)
 void
 client_vleft(struct client_ctx *cc)
 {
-	struct client_ctx	*ci;
 	struct screen_ctx 	*sc = cc->sc;
 	struct geom 		 area;
 
@@ -1102,6 +1101,25 @@ client_vleft(struct client_ctx *cc)
 
 	cc->flags &= ~CLIENT_VMAXIMIZED;
 	cc->geom.x = area.x;
+	cc->geom.y = area.y;
+	cc->geom.w = (area.w - (cc->bwidth * 2)) / 2;
+	cc->geom.h = area.h - (cc->bwidth * 2);
+	client_resize(cc, 1);
+	client_ptrwarp(cc);
+}
+
+void
+client_vright(struct client_ctx *cc)
+{
+	struct screen_ctx 	*sc = cc->sc;
+	struct geom 		 area;
+
+	area = screen_area(sc,
+	    cc->geom.x + cc->geom.w / 2,
+	    cc->geom.y + cc->geom.h / 2, CWM_GAP);
+
+	cc->flags &= ~CLIENT_VMAXIMIZED;
+	cc->geom.x = area.w / 2; /* Unsure if area.w is correct here */
 	cc->geom.y = area.y;
 	cc->geom.w = (area.w - (cc->bwidth * 2)) / 2;
 	cc->geom.h = area.h - (cc->bwidth * 2);

--- a/app/cwm/client.c
+++ b/app/cwm/client.c
@@ -1089,6 +1089,26 @@ client_vtile(struct client_ctx *cc)
 	}
 }
 
+void
+client_vleft(struct client_ctx *cc)
+{
+	struct client_ctx	*ci;
+	struct screen_ctx 	*sc = cc->sc;
+	struct geom 		 area;
+
+	area = screen_area(sc,
+	    cc->geom.x + cc->geom.w / 2,
+	    cc->geom.y + cc->geom.h / 2, CWM_GAP);
+
+	cc->flags &= ~CLIENT_VMAXIMIZED;
+	cc->geom.x = area.x;
+	cc->geom.y = area.y;
+	cc->geom.w = (area.w - (cc->bwidth * 2)) / 2;
+	cc->geom.h = area.h - (cc->bwidth * 2);
+	client_resize(cc, 1);
+	client_ptrwarp(cc);
+}
+
 long
 client_get_wm_state(struct client_ctx *cc)
 {

--- a/app/cwm/conf.c
+++ b/app/cwm/conf.c
@@ -67,6 +67,7 @@ static const struct {
 	{ "window-delete", kbfunc_client_delete, CWM_CONTEXT_CC, 0 },
 	{ "window-htile", kbfunc_client_htile, CWM_CONTEXT_CC, 0 },
 	{ "window-vtile", kbfunc_client_vtile, CWM_CONTEXT_CC, 0 },
+	{ "window-vleft", kbfunc_client_vleft, CWM_CONTEXT_CC, 0 },
 	{ "window-stick", kbfunc_client_toggle_sticky, CWM_CONTEXT_CC, 0 },
 	{ "window-fullscreen", kbfunc_client_toggle_fullscreen, CWM_CONTEXT_CC, 0 },
 	{ "window-maximize", kbfunc_client_toggle_maximize, CWM_CONTEXT_CC, 0 },

--- a/app/cwm/conf.c
+++ b/app/cwm/conf.c
@@ -68,6 +68,7 @@ static const struct {
 	{ "window-htile", kbfunc_client_htile, CWM_CONTEXT_CC, 0 },
 	{ "window-vtile", kbfunc_client_vtile, CWM_CONTEXT_CC, 0 },
 	{ "window-vleft", kbfunc_client_vleft, CWM_CONTEXT_CC, 0 },
+	{ "window-vright", kbfunc_client_vright, CWM_CONTEXT_CC, 0 },
 	{ "window-stick", kbfunc_client_toggle_sticky, CWM_CONTEXT_CC, 0 },
 	{ "window-fullscreen", kbfunc_client_toggle_fullscreen, CWM_CONTEXT_CC, 0 },
 	{ "window-maximize", kbfunc_client_toggle_maximize, CWM_CONTEXT_CC, 0 },

--- a/app/cwm/kbfunc.c
+++ b/app/cwm/kbfunc.c
@@ -229,6 +229,12 @@ kbfunc_client_vleft(void *ctx, struct cargs *cargs)
 }
 
 void
+kbfunc_client_vright(void *ctx, struct cargs *cargs)
+{
+	client_vright(ctx);
+}
+
+void
 kbfunc_client_cycle(void *ctx, struct cargs *cargs)
 {
 	client_cycle(ctx, cargs->flag);

--- a/app/cwm/kbfunc.c
+++ b/app/cwm/kbfunc.c
@@ -223,6 +223,12 @@ kbfunc_client_vtile(void *ctx, struct cargs *cargs)
 }
 
 void
+kbfunc_client_vleft(void *ctx, struct cargs *cargs)
+{
+	client_vleft(ctx);
+}
+
+void
 kbfunc_client_cycle(void *ctx, struct cargs *cargs)
 {
 	client_cycle(ctx, cargs->flag);


### PR DESCRIPTION
WIP This PR will add the following functionality to cwm:
- [x] window-vleft: Send to left half of screen
- [x] window-vright: Send to right half of the screen
- [ ] window-htop: Send to top half of the screen
- [ ] window-hbottom: Send to bottom half of the screen

This is as much for my learning as it is to be useful to anyone who desires to see if it will be useful to them.